### PR TITLE
Fix build.sh: glfw is not linked automatically in macOS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -xe
 
 CFLAGS="-Wall -Wextra -ggdb `pkg-config --cflags raylib`"
 LIBS="`pkg-config --libs raylib` `pkg-config --libs glfw3` -lm -ldl -lpthread"

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-set -xe
+set -e
 
 CFLAGS="-Wall -Wextra -ggdb `pkg-config --cflags raylib`"
-LIBS="`pkg-config --libs raylib` -lglfw -lm -ldl -lpthread"
+LIBS="`pkg-config --libs raylib` `pkg-config --libs glfw3` -lm -ldl -lpthread"
 
 mkdir -p ./build/
 if [ ! -z "${HOTRELOAD}" ]; then


### PR DESCRIPTION
in macOS i cloned and ran: ./build.sh

i got this output:

```
++ pkg-config --cflags raylib
+ CFLAGS='-Wall -Wextra -ggdb -I/opt/homebrew/Cellar/raylib/4.5.0/include'
++ pkg-config --libs raylib
+ LIBS='-L/opt/homebrew/Cellar/raylib/4.5.0/lib -lraylib -lglfw -lm -ldl -lpthread'
+ mkdir -p ./build/
+ '[' '!' -z '' ']'
+ clang -Wall -Wextra -ggdb -I/opt/homebrew/Cellar/raylib/4.5.0/include -o ./build/musializer ./src/plug.c ./src/musializer.c -L/opt/homebrew/Cellar/raylib/4.5.0/lib -lraylib -lglfw -lm -ldl -lpthread -L./build/
ld: library not found for -lglfw
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

i fixed it by modifying the build.sh file to use pkg-config to find and link against glfw