### PR TITLE
add build.zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 music/
 *.mp4
+zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,47 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const raylib_dep = b.dependency("raylib", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // TODO: these resources should all just be embedded inside
+    //       the executable
+    b.installDirectory(.{
+        .source_dir = .{ .path = "resources" },
+        .install_dir = .prefix,
+        .install_subdir = "resources",
+    });
+    const exe = b.addExecutable(.{
+        .name = "musializer",
+        .target = target,
+        .optimize = optimize,
+    });
+    // TODO: add the ".rc" file (does zig support this?)
+    exe.addCSourceFiles(&.{
+        "src/musializer.c",
+        "src/plug.c",
+        switch (target.getOs().tag) {
+            .windows => "src/ffmpeg_windows.c",
+            else => "src/ffmpeg_linux.c",
+        }
+    }, &.{
+        "-Wall",
+        "-Wextra",
+    });
+    exe.linkLibrary(raylib_dep.artifact("raylib"));
+    exe.linkLibC();
+
+    b.installArtifact(exe);
+    const run_cmd = b.addRunArtifact(exe);
+    run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        run_cmd.addArgs(args);
+    }
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = "musializer",
+    .version = "0.0.1",
+
+    .dependencies = .{
+        .raylib = .{
+            .url = "https://github.com/marler8997/raylib/archive/3ae45b8615d4832cb651ea7e45dd1e71887bea28.tar.gz",
+            .hash = "12207c1e1847b1913bdc5f6aefc5024facc6a77921383aa8f8a500d81031893d75b7",
+        },
+    },
+}


### PR DESCRIPTION
Added a `build.zig` which enables building cross-compiling to/from any major platform (i.e. windows/linux/macos).  For example, with this I was able to build and run this on MacOS, and cross compile it to windows from macos.

In general, the benefit of using `build.zig` is that your project has only 1 build-time dependency, zig, which is about an 80 MB download.  This is in contrast to other toolchains which typically require hundreds of packages or complex fragile installations (Visual Studio) that have many tentacles into your system.  Zig's only dependencies are contained within the archive it deploys.