### PR TITLE
Don't omit lpNumberOfBytesWritten parameter passed to WriteFile()

### DIFF
--- a/src/ffmpeg_windows.c
+++ b/src/ffmpeg_windows.c
@@ -113,9 +113,11 @@ FFMPEG *ffmpeg_start_rendering(size_t width, size_t height, size_t fps, const ch
 
 bool ffmpeg_send_frame_flipped(FFMPEG *ffmpeg, void *data, size_t width, size_t height)
 {
+    DWORD written;
+
     for (size_t y = height; y > 0; --y) {
         // TODO: handle ERROR_IO_PENDING
-        if (!WriteFile(ffmpeg->hPipeWrite, (uint32_t*)data + (y - 1)*width, sizeof(uint32_t)*width, NULL, NULL)) {
+        if (!WriteFile(ffmpeg->hPipeWrite, (uint32_t*)data + (y - 1)*width, sizeof(uint32_t)*width, &written, NULL)) {
             TraceLog(LOG_ERROR, "FFMPEG: failed to write into ffmpeg pipe. System Error Code: %d", GetLastError());
             return false;
         }


### PR DESCRIPTION
On Windows 7, this parameter cannot be NULL.
Passing a non-null parameter fixes the program crash.

Reference: https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-writefile