### PR TITLE
rename nob after successful recompile

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -257,14 +257,13 @@ int nob_is_path1_modified_after_path2(const char *path1, const char *path2);
         if (rebuild_is_needed) {                                                             \
             Nob_String_Builder sb = {0};                                                     \
             nob_sb_append_cstr(&sb, binary_path);                                            \
-            nob_sb_append_cstr(&sb, ".old");                                                 \
+            nob_sb_append_cstr(&sb, ".new");                                                 \
             nob_sb_append_null(&sb);                                                         \
                                                                                              \
-            if (!nob_rename(binary_path, sb.items)) exit(1);                                 \
-            if (!NOB_REBUILD_URSELF(binary_path, source_path)) {                             \
-                nob_rename(sb.items, binary_path);                                           \
+            if (!NOB_REBUILD_URSELF(sb.items, source_path)) {                                \
                 exit(1);                                                                     \
             }                                                                                \
+            if (!nob_rename(sb.items, binary_path)) exit(1);                                 \
                                                                                              \
             Nob_Cmd cmd = {0};                                                               \
             nob_da_append_many(&cmd, argv, argc);                                            \


### PR DESCRIPTION
Modifies the rebuild to output to "nob.new" and then rename it to "nob" rather than renaming the current "nob" to "nob.old" and undoing on failure.

This helps in 2 ways.  The first is that the repo stays in a valid state until the new compilation is ready.  With the current method, there's many things that can go wrong between the time nob is renamed to "nob.old" and the time where it "undoes" that on failure, i.e. crash, powerloss, filesystem error, etc.

The second is this method is required to work on Windows.  On Windows you can't rename/modify a running executable.  Note that this change alone isn't enough to make it work on windows, a "handoff" would also be required but it's the first change that would be necessary to accomodate this handoff.  The additional changes needed would be

* execute second build from nob.new.exe
* nob.new.exe copies itself to overwrite nob.exe
* nob.new.exe executes nob.exe and exits
* nob.exe removes nob.new.exe