### PR TITLE
Truncate filenames according to (#33)

### DIFF
--- a/src/plug.c
+++ b/src/plug.c
@@ -438,14 +438,17 @@ void tracks_panel(Rectangle panel_boundary)
 
         size_t text_size = TextLength(text);
         size_t max_char_count = (size_t) (item_boundary.width - text_padding * 2) / (size.x / text_size);
-        
-        char disp_text[max_char_count + 1];
-        memcpy(disp_text, text, max_char_count);
-        memcpy(disp_text + (max_char_count - 2), "...", 3);
-        disp_text[max_char_count] = 0;
-        
+
         // TODO: use SDF fonts
-        DrawTextEx(p->font, disp_text, position, fontSize, 0, WHITE);
+        if(max_char_count > text_size) {
+            DrawTextEx(p->font, text, position, fontSize, 0, WHITE);
+        } else {
+            char disp_text[max_char_count + 1];
+            memcpy(disp_text, text, max_char_count - 3);
+            memcpy(disp_text + (max_char_count - 3), "...", 3);
+            disp_text[max_char_count] = 0;  
+            DrawTextEx(p->font, disp_text, position, fontSize, 0, WHITE);
+        }
     }
     
     if (entire_scrollable_area > visible_area_size) {

--- a/src/plug.c
+++ b/src/plug.c
@@ -435,9 +435,17 @@ void tracks_panel(Rectangle panel_boundary)
             .x = item_boundary.x + text_padding,
             .y = item_boundary.y + item_boundary.height*0.5 - size.y*0.5,
         };
-        // TODO: cut out overflown text
+
+        size_t text_size = TextLength(text);
+        size_t max_char_count = (size_t) (item_boundary.width - text_padding * 2) / (size.x / text_size);
+        
+        char disp_text[max_char_count + 1];
+        memcpy(disp_text, text, max_char_count);
+        memcpy(disp_text + (max_char_count - 2), "...", 3);
+        disp_text[max_char_count] = 0;
+        
         // TODO: use SDF fonts
-        DrawTextEx(p->font, text, position, fontSize, 0, WHITE);
+        DrawTextEx(p->font, disp_text, position, fontSize, 0, WHITE);
     }
     
     if (entire_scrollable_area > visible_area_size) {


### PR DESCRIPTION
Hopefully fixes #33 

Note:
`max_char_count` can't be placed outside the loop since `MeasureTextEx` gives different values for different characters (can't form a constant value containing character width)
