### PR TITLE
Fix tsoding/musializer#24

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 
 #define NOB_IMPLEMENTATION
+/* #define NOB_DA_APPEND_AS_FUNC */
 #include "./src/nob.h"
 
 typedef enum {


### PR DESCRIPTION
Since you were OK to let people open a pull request to "fix" tsoding/musializer#24, then I reimplemented `nob_da_append` and `nob_da_append_many` as functions.

In fact, not completely functions, but rather very small wrappers around actual functions, because I believe it wouldn't have been possible to keep the same macro/function parameters without loosing the knowledge of the actual type and size of the items in the `items` field (I don't know if what I'm saying is clear but you can look at the code anyway if it's not).

Since C functions are not generic, I created a structure (`Nob_Dyn_Array`), type-compatible with all the current dynamic arrays in `nob`, so it's possible to pass them in `nob_da_append` and `nob_da_append_many`.

Also note that we need an lvalue to take the address of in the `nob_da_append` wrapper, so I created a `NOB_TYPEOF` macro, which is defined only with Clang and GCC. So when not compiling with one of those two (or when `NOB_DA_APPEND_AS_FUNC` is not defined), implementation still defaults to yours, of course.

I also made a little macro `nob_da_item` to access the DA items without having to worry about type-casting (idk if it's reeally usefull tbh; I can remove it if it's not).

Also, I thought the intent of `NOB_ASSERT`, `NOB_REALLOC`, etc was to let people choose a custom implementation, so I slightly modified them to be defined in `nob.h` only if the user didn't previously defined it. Again, I can remove that if it's not OK.

I tried to imitate the way you format your code, but of course feel free to make it look as you prefer.

Have a great day

Axel