### PR TITLE
Fix for issue #9: Change the Codepage of the process to UTF-8

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -327,6 +327,12 @@ bool build_musializer(Config config)
                 nob_return_defer(false);
             } else {
                 cmd.count = 0;
+                    nob_cmd_append(&cmd, "rc");
+                    nob_cmd_append(&cmd, "/fo", "./build/musializer.res");
+                    nob_cmd_append(&cmd, "./src/musializer.rc");
+                    // NOTE: Do not change the order of commandline arguments to rc. Their argparser is weird.
+                if (!nob_cmd_run_sync(cmd)) nob_return_defer(false);
+                cmd.count = 0;
                     nob_cmd_append(&cmd, "cl.exe");
                     if (config.microphone) nob_cmd_append(&cmd, "/DFEATURE_MICROPHONE");
                     nob_cmd_append(&cmd, "/I", "./raylib/raylib-4.5.0/src/");
@@ -336,13 +342,12 @@ bool build_musializer(Config config)
                         "./src/plug.c",
                         "./src/ffmpeg_windows.c"
                         // TODO: building resource file is not implemented for TARGET_WIN64_MSVC
-                        //"./build/musializer.res"
                         );
                     nob_cmd_append(&cmd,
                         "/link",
                         nob_temp_sprintf("/LIBPATH:build/raylib/%s", NOB_ARRAY_GET(target_names, config.target)),
                         "raylib.lib");
-                    nob_cmd_append(&cmd, "Winmm.lib", "gdi32.lib", "User32.lib", "Shell32.lib");
+                    nob_cmd_append(&cmd, "Winmm.lib", "gdi32.lib", "User32.lib", "Shell32.lib", "./build/musializer.res");
                     // TODO: is some sort of `-static` flag needed for MSVC to get a statically linked executable
                     //nob_cmd_append(&cmd, "-static");
                 if (!nob_cmd_run_sync(cmd)) nob_return_defer(false);

--- a/src/musializer.rc
+++ b/src/musializer.rc
@@ -1,1 +1,3 @@
+#include <winuser.h>
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "utf8.xml"
 id ICON "./resources/logo/logo-256.ico"

--- a/src/utf8.xml
+++ b/src/utf8.xml
@@ -1,0 +1,8 @@
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+    <assemblyIdentity type="win32" name="..." version="6.0.0.0" />
+    <application>
+        <windowsSettings>
+            <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+        </windowsSettings>
+    </application>
+</assembly>


### PR DESCRIPTION
To support loading filenames with unicode characters on windows, declare UTF-8 support in the manifest file.