### PR TITLE
Remove need for nob boostrapping on *nix systems

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -1,3 +1,9 @@
+#if 0
+    EXEC="${0%.*}"
+    [ -x "$EXEC" ] || gcc -O3 -o "$EXEC" "$0"
+    exec "$EXEC" "$@"
+#endif
+
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Working on my own stuff, I ran across this Stackoverflow question regarding making C source files executable:

https://stackoverflow.com/questions/2482348/run-c-or-c-file-as-a-script

I thought it might be a good fit for nob. With this change, one only ever needs to run `./nob.c` to build it.

You might think it's too superfluous or "weird",  which is fine, but I at least wanted wanted to put it out there.

I didn't update the README.md, not being entirely sure how to best change it.

In any case, you might want to update Musializer's  README to reference Raylib's documentation on what dependencies are required to build. I had to do a bit of digging to figure it out:

https://github.com/raysan5/raylib/wiki/Working-on-GNU-Linux