### PR TITLE
closes #45 readdir, closedir, opendir static in nob.h

### DIFF
--- a/src/nob.h
+++ b/src/nob.h
@@ -364,9 +364,9 @@ struct dirent
 
 typedef struct DIR DIR;
 
-DIR *opendir(const char *dirpath);
-struct dirent *readdir(DIR *dirp);
-int closedir(DIR *dirp);
+static DIR *opendir(const char *dirpath);
+static struct dirent *readdir(DIR *dirp);
+static int closedir(DIR *dirp);
 #endif // _WIN32
 // minirent.h HEADER END ////////////////////////////////////////
 


### PR DESCRIPTION
raylib.lib(rcore.obj) link errors resolved via static definition in nob.h.