### PR TITLE
Use correct functions for getting window size

### DIFF
--- a/src/plug.c
+++ b/src/plug.c
@@ -428,7 +428,7 @@ static void timeline(Rectangle timeline_boundary, Track *track)
 
     float played = GetMusicTimePlayed(track->music);
     float len = GetMusicTimeLength(track->music);
-    float x = played/len*GetRenderWidth();
+    float x = played/len*GetScreenWidth();
     Vector2 startPos = {
         .x = x,
         .y = timeline_boundary.y
@@ -782,8 +782,8 @@ static bool volume_slider(Rectangle preview_boundary)
 
 static void preview_screen(void)
 {
-    int w = GetRenderWidth();
-    int h = GetRenderHeight();
+    int w = GetScreenWidth();
+    int h = GetScreenHeight();
 
     if (IsFileDropped()) {
         FilePathList droppedFiles = LoadDroppedFiles();
@@ -945,8 +945,8 @@ static void preview_screen(void)
 #ifdef FEATURE_MICROPHONE
 static void capture_screen(void)
 {
-    int w = GetRenderWidth();
-    int h = GetRenderHeight();
+    int w = GetScreenWidth();
+    int h = GetScreenHeight();
 
     if (p->microphone != NULL) {
         if (IsKeyPressed(KEY_CAPTURE) || IsKeyPressed(KEY_ESCAPE)) {
@@ -957,7 +957,7 @@ static void capture_screen(void)
 
         size_t m = fft_analyze(GetFrameTime());
         fft_render(CLITERAL(Rectangle) {
-            0, 0, GetRenderWidth(), GetRenderHeight()
+            0, 0, GetScreenWidth(), GetScreenHeight()
         }, m);
     } else {
         if (IsKeyPressed(KEY_ESCAPE)) {
@@ -986,8 +986,8 @@ static void capture_screen(void)
 
 void rendering_screen(void)
 {
-    int w = GetRenderWidth();
-    int h = GetRenderHeight();
+    int w = GetScreenWidth();
+    int h = GetScreenHeight();
 
     Track *track = current_track();
     NOB_ASSERT(track != NULL);


### PR DESCRIPTION
In raylib 5.0, the `GetRender(Width|Height)` functions account for HighDPI on macOS, but this causes the issue mentioned in this comment: https://github.com/tsoding/musializer/issues/52#issuecomment-1824789213

I believe the correct way to get the window's width and height are the `GetScreen(Width|Height)` functions. On non-macOS platforms, they are currently identical, but that may change in the future.