### PR TITLE
Implement drag-after-click for volume slider

### DIFF
--- a/src/plug.c
+++ b/src/plug.c
@@ -763,6 +763,7 @@ static bool horz_slider(Rectangle boundary, float *value, bool *dragging)
                 if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
                     *value = slider_get_value(mouse.x, startPos.x, endPos.x);
                     updated = true;
+                    *dragging = true;
                 }
             }
         }


### PR DESCRIPTION
In my opinion, this is a bug: you can press the volume slider and the volume will change, but you can't drag the slider without releasing the button (and clicking it again).

This PR adds that kind of functionality.