### PR TITLE
Fixed miscalculating the window dimensions

### DIFF
--- a/src/plug.c
+++ b/src/plug.c
@@ -919,8 +919,8 @@ static void popup_tray(Popup_Tray *pt, Rectangle preview_boundary)
 
 static void preview_screen(void)
 {
-    int w = GetRenderWidth();
-    int h = GetRenderHeight();
+    int w = GetScreenWidth();
+    int h = GetScreenHeight();
 
     if (IsFileDropped()) {
         FilePathList droppedFiles = LoadDroppedFiles();
@@ -1121,8 +1121,8 @@ static void preview_screen(void)
 #ifdef MUSIALIZER_MICROPHONE
 static void capture_screen(void)
 {
-    int w = GetRenderWidth();
-    int h = GetRenderHeight();
+    int w = GetScreenWidth();
+    int h = GetScreenHeight();
 
     if (p->microphone != NULL) {
         if (IsKeyPressed(KEY_CAPTURE) || IsKeyPressed(KEY_ESCAPE)) {
@@ -1162,8 +1162,8 @@ static void capture_screen(void)
 
 static void rendering_screen(void)
 {
-    int w = GetRenderWidth();
-    int h = GetRenderHeight();
+    int w = GetScreenWidth();
+    int h = GetScreenHeight();
 
     Track *track = current_track();
     NOB_ASSERT(track != NULL);


### PR DESCRIPTION
Platform: macOS 14.1.1

Description: running the application on my machine elements would not be rendered correctly e.g. text and other UI elements overflow out of the screen and the visualizer is cropped off.

Fix: replacing `GetRenderWidth`, `GetRenderHeight` with `GetScreenWidth`, `GetScreenHeight` from raylib solves the issue and as stated in the docs 

```c
    int GetScreenWidth(void);                                   // Get current screen width
    int GetScreenHeight(void);                                  // Get current screen height
    int GetRenderWidth(void);                                   // Get current render width (it considers HiDPI)
    int GetRenderHeight(void);                                  // Get current render height (it considers HiDPI)
```

Note: I have not been able to test the results on other platforms but it indeed works for my environment. I have attached pictures of the output before and after the modifications.

### Before 
 
<img width="1470" alt="berfore-4" src="https://github.com/tsoding/musializer/assets/92385434/06fa4774-e0a5-42f3-940d-b1ac1a7b3930">
<img width="1470" alt="before-3" src="https://github.com/tsoding/musializer/assets/92385434/bdcd8800-2d80-4d31-9cbb-b47016e02bc1">
<img width="1470" alt="before-2" src="https://github.com/tsoding/musializer/assets/92385434/35fb41e2-b049-418a-8ecb-a5acea3d3dba">
<img width="1470" alt="before-1" src="https://github.com/tsoding/musializer/assets/92385434/2675ddfb-6464-47e5-94dc-3a9b54f8f12c">

### After 
<img width="1470" alt="after-2" src="https://github.com/tsoding/musializer/assets/92385434/5795e0ef-5145-49f6-9acf-dd57131620a4">
<img width="1470" alt="after-3" src="https://github.com/tsoding/musializer/assets/92385434/fb8ef2c0-49cd-42df-8450-e7d77773e51d">
<img width="1470" alt="after-1" src="https://github.com/tsoding/musializer/assets/92385434/c9463677-e3af-4d16-ac43-0fc4cae7e336">
