### PR TITLE
Remove unused includes

### DIFF
--- a/src/musializer.c
+++ b/src/musializer.c
@@ -1,10 +1,7 @@
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 #include <complex.h>
-#include <math.h>
 
 #include <raylib.h>
 


### PR DESCRIPTION
At least on MacOS, these three includes appear to be not used.

Confirming also that `nob` works on MacOS Sonoma.