### PR TITLE
Fix multiple decleration issue of nob.h's implementations

### DIFF
--- a/src/nob.h
+++ b/src/nob.h
@@ -370,8 +370,6 @@ int closedir(DIR *dirp);
 #endif // _WIN32
 // minirent.h HEADER END ////////////////////////////////////////
 
-#endif // NOB_H_
-
 #ifdef NOB_IMPLEMENTATION
 
 static size_t nob_temp_size = 0;
@@ -1155,3 +1153,4 @@ int closedir(DIR *dirp)
 // minirent.h SOURCE END ////////////////////////////////////////
 
 #endif
+#endif // NOB_H_


### PR DESCRIPTION
Well you can probably guess what's the issue by looking at the commit... anyways not sure if `nob.h` was intended to be used like this way: 
extra.h
```
#include "nob.h"
/* does something extra epic */
```
nob.c
```C
#define NOB_IMPLEMENTATION
#include "nob.h"
/* leads to multiple decleration linker error */
#include "extra.h"
```

Just in case :)