### PR TITLE
Add Github workflow

### DIFF
--- a/.github/workflows/nob.yaml
+++ b/.github/workflows/nob.yaml
@@ -1,0 +1,60 @@
+name: no-build build
+on: [push, pull_request]
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+      - name: Clone GIT repo
+        uses: actions/checkout@v4
+      - name: Build nob
+        run: clang -o nob nob.c
+      - name: Run nob
+        run: ./nob
+      - name: Upload build folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-build-folder
+          path: build/
+  ubuntu:
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone GIT repo
+        uses: actions/checkout@v4
+      - name: Pull Deps
+        run: sudo apt install xorg-dev
+      - name: Build nob
+        run: ${{ matrix.cc }} -o nob nob.c
+      - name: Run nob
+        run: ./nob
+      - name: Upload build folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: ubuntu-${{ matrix.cc }}-build-folder
+          path: build/
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Clone GIT repo
+        uses: actions/checkout@v4
+      - name: Build nob
+        shell: cmd
+        # cl.exe isn't available as-is in Github images because they don't want
+        # to, so we need to pull env vars ourselves. Refs:
+        # https://github.com/actions/runner-images/issues/6205#issuecomment-1241573412
+        # https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#create-your-own-command-prompt-shortcut
+        run: |
+          call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
+          cl.exe -o nob.exe nob.c
+      - name: Run nob
+        shell: cmd
+        run: nob.exe
+      - name: Upload build folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-build-folder
+          path: build/
+


### PR DESCRIPTION
The beauty of `nob` is how we can build Musialiser with a simple interface:

```
cc -o nob nob.c
./nob
```

(or equivalent in Windows)

We can leverage this simplicity and slap a simple Github workflow to test the build in all platforms. (Feel free to insert the flex slap meme here).

I took the liberty of setting this to be triggered by `push` and `pull_request`, so it can do a basic check whenever someone wants to create a PR in this repo.

I _think_ this can be extended to test build for multiple configurations (hotreload, etc) but I decided to start with something simpler.

**Note:** Build on Windows (that niche gaming platform) is failing with the same error as #62. Mac and Ubuntu are passing in my fork.