### PR TITLE
Update nob_file_exists to distinguish between errors on windows.

### DIFF
--- a/src/nob.h
+++ b/src/nob.h
@@ -1,6 +1,5 @@
 // This is a complete backward incompatible rewrite of https://github.com/tsoding/nobuild
 // because I'm really unhappy with the direction it is going. It's gonna sit in this repo
-// [Sir_Lurksal0t] I hereby yoink, repo referenced: https://github.com/tsoding/musializer
 // until it's matured enough and then I'll probably extract it to its own repo.
 
 // Copyright 2023 Alexey Kutepov <reximkut@gmail.com>

--- a/src/nob.h
+++ b/src/nob.h
@@ -603,9 +603,7 @@ bool nob_proc_wait(Nob_Proc proc)
     }
 
     if (exit_status != 0) {
-        LPTSTR errorText = nob_get_last_windows_error_name();
-        nob_log(NOB_ERROR, "Command exited with exit code: %s", errorText);
-        LocalFree(errorText);
+        nob_log(NOB_ERROR, "Command exited with exit code: %d", exit_status);
         return false;
     }
 


### PR DESCRIPTION
Update nob_file_exists to distinguish between "does not exists" and other windows errors (todo).

Couldn't get nob to compile and thought #if _WIN32 was the cause, forked already, and then noticed that it doesn't matter, it was something on my end. So I decided to just go ahead and fix something, and #ifdef _WIN32 is now just a consistancy/cleanliness bonus.
Had some trouble with FormatMessage, so helped myself to the answer from stackoverflow.com/questions/455434