### PR TITLE
Enable flac support

### DIFF
--- a/raylib/raylib-5.0/src/config.h
+++ b/raylib/raylib-5.0/src/config.h
@@ -225,7 +225,7 @@
 #define SUPPORT_FILEFORMAT_OGG          1
 #define SUPPORT_FILEFORMAT_MP3          1
 #define SUPPORT_FILEFORMAT_QOA          1
-//#define SUPPORT_FILEFORMAT_FLAC         1
+#define SUPPORT_FILEFORMAT_FLAC         1
 #define SUPPORT_FILEFORMAT_XM           1
 #define SUPPORT_FILEFORMAT_MOD          1
 


### PR DESCRIPTION
This simple fix enables Flac support as mentioned by #78. This helps generate videos/visualizations of lossless music.

No other modifications are required. Just running nob (cleanly) rebuilds raylib and musializer with Flac support.