### PR TITLE
FIX: genf macro lineno

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -67,7 +67,7 @@ void log_config(Nob_Log_Level level)
 #define genf(out, ...) \
     do { \
         fprintf((out), __VA_ARGS__); \
-        fprintf((out), " // %s:%d\n", __FILE__, __LINE__ - 1); \
+        fprintf((out), " // %s:%d\n", __FILE__, __LINE__); \
     } while(0)
 
 typedef struct {


### PR DESCRIPTION
The correct line number of the source file for the generated code.

See for example following code and it's output:
```c
#include <stdio.h>

#define genf(out, ...)                                     \
    do {                                                   \
        fprintf((out), __VA_ARGS__);                       \
        fprintf((out), " // %s:%d\n", __FILE__, __LINE__); \
    } while (0)

int main(void) {
    genf(stdout, "Hello, world");
}
```