### PR TITLE
refactor bundle byte print in rows

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -132,19 +132,9 @@ bool generate_resource_bundle(void)
 
     genf(out, "unsigned char bundle[] = {");
     size_t row_size = 20;
-    for (size_t row = 0; row < bundle.count/row_size; ++row){
+    for (size_t i = 0; i < bundle.count; ++i){
         fprintf(out, "     ");
-        for (size_t col = 0; col < row_size; ++col) {
-            size_t i = row*row_size + col;
-            fprintf(out, "0x%02X, ", (unsigned char)bundle.items[i]);
-        }
-        genf(out, "");
-    }
-    size_t remainder = bundle.count%row_size;
-    if (remainder > 0) {
-        fprintf(out, "     ");
-        for (size_t col = 0; col < remainder; ++col) {
-            size_t i = bundle.count/row_size*row_size + col;
+        for (size_t col = 0; col < row_size && i < bundle.count; ++col, ++i) {
             fprintf(out, "0x%02X, ", (unsigned char)bundle.items[i]);
         }
         genf(out, "");


### PR DESCRIPTION
Hello Tsoding,
the operation of printing full rows and the last reminder row can both happen in a single impl.
the inner loop checks for both ROW count and also preserve overall SIZE limit.

here is a runnable example in JS:
```javascript
var data = [...new Array(100)].map((_,i)=>i+101);

var row_size = 7;
for(let i=0; i<data.length; ++i) {
    var out = "    ";
    for (let w=0; w<row_size  && i<data.length; ++w, ++i) {
        out += data[i].toString() + ", ";
    }
    console.log(out);
}
```