### PR TITLE
Fix nob's program name on windows

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -315,15 +315,6 @@ void generate_default_config(Nob_String_Builder *content)
 
 int main(int argc, char **argv)
 {
-    #ifdef _WIN32
-    if (strstr(argv[0], ".exe") == NULL) {
-        char* temp = malloc(strlen(argv[0]) + 5);
-        strcpy(temp, argv[0]);
-        strcat(temp, ".exe");
-        argv[0] = temp;
-    }
-    #endif // _WIN32
-    
     NOB_GO_REBUILD_URSELF(argc, argv);
 
     const char *program = nob_shift_args(&argc, &argv);

--- a/nob.c
+++ b/nob.c
@@ -315,6 +315,15 @@ void generate_default_config(Nob_String_Builder *content)
 
 int main(int argc, char **argv)
 {
+    #ifdef _WIN32
+    if (strstr(argv[0], ".exe") == NULL) {
+        char* temp = malloc(strlen(argv[0]) + 5);
+        strcpy(temp, argv[0]);
+        strcat(temp, ".exe");
+        argv[0] = temp;
+    }
+    #endif // _WIN32
+    
     NOB_GO_REBUILD_URSELF(argc, argv);
 
     const char *program = nob_shift_args(&argc, &argv);

--- a/src/nob.h
+++ b/src/nob.h
@@ -236,7 +236,7 @@ int nob_file_exists(const char *file_path);
 #endif
 
 #ifdef _WIN32
-#define FIX_ARGV(argv)                                 \
+#define NOB_FIX_ARGV(argv)                             \
     do {                                               \
         if (strstr(argv[0], ".exe") == NULL) {         \
             char* temp = malloc(strlen(argv[0]) + 5);  \
@@ -246,7 +246,7 @@ int nob_file_exists(const char *file_path);
         }                                              \
     } while(0)
 #else
-#define FIX_ARGV(argv)
+#define NOB_FIX_ARGV(argv)
 #endif
 
 // Go Rebuild Urself™ Technology
@@ -273,7 +273,7 @@ int nob_file_exists(const char *file_path);
 //
 #define NOB_GO_REBUILD_URSELF(argc, argv)                                                    \
     do {                                                                                     \
-        FIX_ARGV(argv);                                                                      \
+        NOB_FIX_ARGV(argv);                                                                  \
         const char *source_path = __FILE__;                                                  \
         assert(argc >= 1);                                                                   \
         const char *binary_path = argv[0];                                                   \

--- a/src/nob.h
+++ b/src/nob.h
@@ -235,6 +235,20 @@ int nob_file_exists(const char *file_path);
 #  endif
 #endif
 
+#ifdef _WIN32
+#define FIX_ARGV(argv)                                 \
+    do {                                               \
+        if (strstr(argv[0], ".exe") == NULL) {         \
+            char* temp = malloc(strlen(argv[0]) + 5);  \
+            strcpy(temp, argv[0]);                     \
+            strcat(temp, ".exe");                      \
+            argv[0] = temp;                            \
+        }                                              \
+    } while(0)
+#else
+#define FIX_ARGV(argv)
+#endif
+
 // Go Rebuild Urself™ Technology
 //
 //   How to use it:
@@ -259,6 +273,7 @@ int nob_file_exists(const char *file_path);
 //
 #define NOB_GO_REBUILD_URSELF(argc, argv)                                                    \
     do {                                                                                     \
+        FIX_ARGV(argv);                                                                      \
         const char *source_path = __FILE__;                                                  \
         assert(argc >= 1);                                                                   \
         const char *binary_path = argv[0];                                                   \


### PR DESCRIPTION
Although executable on windows end with `.exe` they can be called without them. This makes `argv[0]` different from the actual name of the program (nob.exe) and causes `MoveFileEx` to fail.