### PR TITLE
Add FLAC support without changing raylib source code

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,8 @@ Alpha Release 3
 - Finally got rid of the resource/ folder. It's now part of the
   executable
 
+- Added FLAC support
+
 Windows Alpha Release 2
 ----------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ https://github.com/tsoding/musializer/assets/165283/8b9f9653-9b3d-4c04-9569-338f
 - qoa
 - xm
 - mod
-- flac (in development)
+- flac
 
 ## Download Binaries
 

--- a/src/nob_linux.c
+++ b/src/nob_linux.c
@@ -99,7 +99,7 @@ bool build_raylib(void)
         if (nob_needs_rebuild(output_path, &input_path, 1)) {
             cmd.count = 0;
             nob_cmd_append(&cmd, "cc");
-            nob_cmd_append(&cmd, "-ggdb", "-DPLATFORM_DESKTOP", "-fPIC");
+            nob_cmd_append(&cmd, "-ggdb", "-DPLATFORM_DESKTOP", "-fPIC", "-DSUPPORT_FILEFORMAT_FLAC=1");
             nob_cmd_append(&cmd, "-I./raylib/raylib-"RAYLIB_VERSION"/src/external/glfw/include");
             nob_cmd_append(&cmd, "-c", input_path);
             nob_cmd_append(&cmd, "-o", output_path);

--- a/src/nob_macos.c
+++ b/src/nob_macos.c
@@ -98,7 +98,7 @@ bool build_raylib(void)
         if (nob_needs_rebuild(output_path, &input_path, 1)) {
             cmd.count = 0;
             nob_cmd_append(&cmd, "clang");
-            nob_cmd_append(&cmd, "-g", "-DPLATFORM_DESKTOP", "-fPIC");
+            nob_cmd_append(&cmd, "-g", "-DPLATFORM_DESKTOP", "-fPIC", "-DSUPPORT_FILEFORMAT_FLAC=1");
             nob_cmd_append(&cmd, "-I./raylib/raylib-"RAYLIB_VERSION"/src/external/glfw/include");
             nob_cmd_append(&cmd, "-Iexternal/glfw/deps/ming");
             nob_cmd_append(&cmd, "-DGRAPHICS_API_OPENGL_33");

--- a/src/nob_openbsd.c
+++ b/src/nob_openbsd.c
@@ -99,7 +99,7 @@ bool build_raylib(void)
         if (nob_needs_rebuild(output_path, &input_path, 1)) {
             cmd.count = 0;
             nob_cmd_append(&cmd, "cc");
-            nob_cmd_append(&cmd, "-ggdb", "-DPLATFORM_DESKTOP", "-fPIC");
+            nob_cmd_append(&cmd, "-ggdb", "-DPLATFORM_DESKTOP", "-fPIC", "-DSUPPORT_FILEFORMAT_FLAC=1");
             nob_cmd_append(&cmd, "-I./raylib/raylib-"RAYLIB_VERSION"/src/external/glfw/include");
             nob_cmd_append(&cmd, "-c", input_path);
             nob_cmd_append(&cmd, "-o", output_path);

--- a/src/nob_win64_mingw.c
+++ b/src/nob_win64_mingw.c
@@ -76,7 +76,7 @@ bool build_raylib()
         if (nob_needs_rebuild(output_path, &input_path, 1)) {
             cmd.count = 0;
             nob_cmd_append(&cmd, "x86_64-w64-mingw32-gcc");
-            nob_cmd_append(&cmd, "-ggdb", "-DPLATFORM_DESKTOP", "-fPIC");
+            nob_cmd_append(&cmd, "-ggdb", "-DPLATFORM_DESKTOP", "-fPIC", "-DSUPPORT_FILEFORMAT_FLAC=1");
             nob_cmd_append(&cmd, "-DPLATFORM_DESKTOP");
             nob_cmd_append(&cmd, "-fPIC");
             nob_cmd_append(&cmd, "-I./raylib/raylib-"RAYLIB_VERSION"/src/external/glfw/include");

--- a/src/nob_win64_msvc.c
+++ b/src/nob_win64_msvc.c
@@ -72,7 +72,7 @@ bool build_raylib(void)
 
         if (nob_needs_rebuild(output_path, &input_path, 1)) {
             cmd.count = 0;
-            nob_cmd_append(&cmd, "cl.exe", "/DPLATFORM_DESKTOP");
+            nob_cmd_append(&cmd, "cl.exe", "/DPLATFORM_DESKTOP", "/DSUPPORT_FILEFORMAT_FLAC=1");
             nob_cmd_append(&cmd, "/I", "./raylib/raylib-"RAYLIB_VERSION"/src/external/glfw/include");
             nob_cmd_append(&cmd, "/c", input_path);
             nob_cmd_append(&cmd, nob_temp_sprintf("/Fo%s", output_path));


### PR DESCRIPTION
These changes should build `raylib` with `-DSUPPORT_FILEFORMAT_FLAC=1`.

This enables FLAC support as mentioned in #78.

I tested both `TARGET_LINUX` and `TARGET_WIN64_MINGW` and a sample FLAC file just works on both.

Notes:

- Maybe the flag could be passed only to the `raudio.c` module build step. But I don't know if that definition changes anything else and may be needed for all modules anyway. 
- Maybe this could be done in a different way. I didn't want to assume too much and insert unrequested complexity, so a little more thought could shape this support introduction better than this bare minimum idea.

- I don't think an additional configure option for the repo's build is needed (in order to have this be flexible/optional).
  - For now, the available configure options (hotreloading, bundled come to mind) seem fare more relevant than what this would offer.
- I guess it mostly comes down to the downsides of turning this support on.
  - Don't know much about that, but may need to be looked into.
  - For now I can say that on my system the binary size increased:
    - from `5174kB` to `5548kB`, so ~7% (on `TARGET_LINUX`)
    - from `5723kB` to `6085kB`, so ~6% (on `TARGET_WIN64_MINGW`)