### PR TITLE
BUGFIX: vol slider tooltip disappearing

### DIFF
--- a/src/plug.c
+++ b/src/plug.c
@@ -644,6 +644,16 @@ static void tooltip(Rectangle boundary, const char *text, Side align)
     p->tooltip_element_boundary = boundary;
 }
 
+static void tooltip_persistent(Rectangle boundary, const char *text, Side align, bool persists)
+{
+    if (!CheckCollisionPointRec(GetMousePosition(), boundary) && !persists) return;
+    p->tooltip_show = true;
+    // TODO: this may not work properly if text contains UTF-8
+    snprintf(p->tooltip_buffer, sizeof(p->tooltip_buffer), "%s", text);
+    p->tooltip_align = align;
+    p->tooltip_element_boundary = boundary;
+}
+
 static void timeline(Rectangle timeline_boundary, Track *track)
 {
     DrawRectangleRec(timeline_boundary, COLOR_TIMELINE_BACKGROUND);
@@ -1057,8 +1067,7 @@ static bool volume_slider_with_location(const char *file, int line, Rectangle vo
         if (volume > 1) volume = 1;
         SetMasterVolume(volume);
 
-        // TODO: if while dragging the volume slider you hoverout of it, the tooltip disappears
-        tooltip(slider_boundary, TextFormat("Volume %d%%", (int)floorf(volume*100.0f)), SIDE_TOP);
+        tooltip_persistent(slider_boundary, TextFormat("Volume %d%%", (int)floorf(volume*100.0f)), SIDE_TOP, dragging);
     }
 
     // Toggle mute

--- a/src/plug.c
+++ b/src/plug.c
@@ -646,7 +646,7 @@ static void tooltip(Rectangle boundary, const char *text, Side align)
 
 static void tooltip_persistent(Rectangle boundary, const char *text, Side align, bool persists)
 {
-    if (!CheckCollisionPointRec(GetMousePosition(), boundary) && !persists) return;
+    if (!(CheckCollisionPointRec(GetMousePosition(), boundary) || persists)) return;
     p->tooltip_show = true;
     // TODO: this may not work properly if text contains UTF-8
     snprintf(p->tooltip_buffer, sizeof(p->tooltip_buffer), "%s", text);

--- a/src/plug.c
+++ b/src/plug.c
@@ -634,17 +634,7 @@ static void end_tooltip_frame(void)
     DrawTextEx(p->font, p->tooltip_buffer, position, fontSize, spacing, COLOR_TOOLTIP_FOREGROUND);
 }
 
-static void tooltip(Rectangle boundary, const char *text, Side align)
-{
-    if (!CheckCollisionPointRec(GetMousePosition(), boundary)) return;
-    p->tooltip_show = true;
-    // TODO: this may not work properly if text contains UTF-8
-    snprintf(p->tooltip_buffer, sizeof(p->tooltip_buffer), "%s", text);
-    p->tooltip_align = align;
-    p->tooltip_element_boundary = boundary;
-}
-
-static void tooltip_persistent(Rectangle boundary, const char *text, Side align, bool persists)
+static void tooltip(Rectangle boundary, const char *text, Side align, bool persists)
 {
     if (!(CheckCollisionPointRec(GetMousePosition(), boundary) || persists)) return;
     p->tooltip_show = true;
@@ -932,9 +922,9 @@ static int fullscreen_button_with_loc(const char *file, int line, Rectangle full
     DrawTexturePro(assets_texture("./resources/icons/fullscreen.png"), source, dest, CLITERAL(Vector2){0}, 0, ColorBrightness(WHITE, -0.10));
 
     if (p->fullscreen) {
-        tooltip(fullscreen_button_boundary, "Collapse [F]", SIDE_TOP);
+        tooltip(fullscreen_button_boundary, "Collapse [F]", SIDE_TOP, false);
     } else {
-        tooltip(fullscreen_button_boundary, "Expand [F]", SIDE_TOP);
+        tooltip(fullscreen_button_boundary, "Expand [F]", SIDE_TOP, false);
     }
 
     return state;
@@ -1067,7 +1057,7 @@ static bool volume_slider_with_location(const char *file, int line, Rectangle vo
         if (volume > 1) volume = 1;
         SetMasterVolume(volume);
 
-        tooltip_persistent(slider_boundary, TextFormat("Volume %d%%", (int)floorf(volume*100.0f)), SIDE_TOP, dragging);
+        tooltip(slider_boundary, TextFormat("Volume %d%%", (int)floorf(volume*100.0f)), SIDE_TOP, dragging);
     }
 
     // Toggle mute
@@ -1091,9 +1081,9 @@ static bool volume_slider_with_location(const char *file, int line, Rectangle vo
     }
 
     if (volume <= 0.0) {
-        tooltip(volume_icon_boundary, "Unmute [M]", SIDE_TOP);
+        tooltip(volume_icon_boundary, "Unmute [M]", SIDE_TOP, false);
     } else {
-        tooltip(volume_icon_boundary, "Mute [M]", SIDE_TOP);
+        tooltip(volume_icon_boundary, "Mute [M]", SIDE_TOP, false);
     }
 
     return dragging || updated;
@@ -1167,9 +1157,9 @@ static int play_button_with_location(const char *file, int line, Track *track, R
     DrawTexturePro(assets_texture("./resources/icons/play.png"), source, dest, CLITERAL(Vector2){0}, 0, ColorBrightness(WHITE, -0.10));
 
     if (IsMusicStreamPlaying(track->music)) {
-        tooltip(boundary, "Pause [SPACE]", SIDE_TOP);
+        tooltip(boundary, "Pause [SPACE]", SIDE_TOP, false);
     } else {
-        tooltip(boundary, "Play [SPACE]", SIDE_TOP);
+        tooltip(boundary, "Play [SPACE]", SIDE_TOP, false);
     }
 
     return state;
@@ -1198,7 +1188,7 @@ static int render_button_with_location(const char *file, int line, Rectangle bou
     Rectangle source = {icon_size*icon_index, 0, icon_size, icon_size};
     DrawTexturePro(assets_texture("./resources/icons/render.png"), source, dest, CLITERAL(Vector2){0}, 0, ColorBrightness(WHITE, -0.10));
 
-    tooltip(boundary, "Render [R]", SIDE_TOP);
+    tooltip(boundary, "Render [R]", SIDE_TOP, false);
 
     return state;
 }


### PR DESCRIPTION
The volume slider tooltip was disappearing while the slider was being dragged and the mouse pointer was outside of its boundary. This is fixed here.
![musializer-vol-tooltip](https://github.com/tsoding/musializer/assets/17234315/0d86d661-1a70-44c3-8a85-f0cecf7df1f6)
