### PR TITLE
fix messup when moving MUSIALIZER_PLUG

### DIFF
--- a/src/plug.c
+++ b/src/plug.c
@@ -16,14 +16,14 @@
 #include <raylib.h>
 #include <rlgl.h>
 
-#ifndef MUSIALIZER_UNBUNDLE
-#include "bundle.h"
-
 #ifdef _WIN32
 #define MUSIALIZER_PLUG __declspec(dllexport)
 #else
 #define MUSIALIZER_PLUG
 #endif
+
+#ifndef MUSIALIZER_UNBUNDLE
+#include "bundle.h"
 
 MUSIALIZER_PLUG void plug_free_resource(void *data)
 {


### PR DESCRIPTION
Zozin I apologize for not noticing this when I pushed the fix in #90. I accidentally put the macro inside the `#ifndef MUSIALIALIZER_UNBUNDLE`.