### PR TITLE
Unlock fps during video rendering

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -284,6 +284,9 @@ void generate_default_config(Nob_String_Builder *content)
     nob_sb_append_cstr(content, "\n");
     nob_sb_append_cstr(content, "//// Unfinished feature that enables capturing sound from the mic.\n");
     nob_sb_append_cstr(content, "// #define MUSIALIZER_MICROPHONE\n");
+    nob_sb_append_cstr(content, "\n");
+    nob_sb_append_cstr(content, "// Desired rendering FPS of the application.\n");
+    nob_sb_append_cstr(content, "#define MUSIALIZER_TARGET_FPS 60\n");
 }
 
 int main(int argc, char **argv)

--- a/src/musializer.c
+++ b/src/musializer.c
@@ -9,6 +9,7 @@
 #include <signal.h> // needed for sigaction()
 #endif // _WIN32
 
+#include "config.h"
 #include "./hotreload.h"
 
 int main(void)
@@ -36,7 +37,7 @@ int main(void)
         SetWindowIcon(logo);
         plug_free_resource(data);
     }
-    SetTargetFPS(60);
+    SetTargetFPS(MUSIALIZER_TARGET_FPS);
     SetExitKey(KEY_NULL);
     InitAudioDevice();
 

--- a/src/plug.c
+++ b/src/plug.c
@@ -1250,8 +1250,19 @@ static void start_rendering_track(Track *track)
     // TODO: set the rendering output path based on the input path
     // Basically output into the same folder
     p->ffmpeg = ffmpeg_start_rendering(p->screen.texture.width, p->screen.texture.height, RENDER_FPS, track->file_path);
+    SetTargetFPS(0);
     p->rendering = true;
     SetTraceLogLevel(LOG_WARNING);
+}
+
+static void finish_rendering_track(Track *track) {
+    SetTraceLogLevel(LOG_INFO);
+    UnloadWave(p->wave);
+    UnloadWaveSamples(p->wave_samples);
+    SetTargetFPS(MUSIALIZER_TARGET_FPS);
+    p->rendering = false;
+    fft_clean();
+    PlayMusicStream(track->music);
 }
 
 #ifdef MUSIALIZER_MICROPHONE
@@ -1615,12 +1626,7 @@ static void rendering_screen(void)
     NOB_ASSERT(track != NULL);
     if (p->ffmpeg == NULL) { // Starting FFmpeg process has failed for some reason
         if (IsKeyPressed(KEY_ESCAPE)) {
-            SetTraceLogLevel(LOG_INFO);
-            UnloadWave(p->wave);
-            UnloadWaveSamples(p->wave_samples);
-            p->rendering = false;
-            fft_clean();
-            PlayMusicStream(track->music);
+            finish_rendering_track(track);
         }
 
         const char *label = "FFmpeg Failure: Check the Logs";
@@ -1654,12 +1660,7 @@ static void rendering_screen(void)
                 // cause it should deallocate all the resources even in case of a failure.
                 p->ffmpeg = NULL;
             } else {
-                SetTraceLogLevel(LOG_INFO);
-                UnloadWave(p->wave);
-                UnloadWaveSamples(p->wave_samples);
-                p->rendering = false;
-                fft_clean();
-                PlayMusicStream(track->music);
+                finish_rendering_track(track);
             }
         } else { // Rendering is going...
             // Label


### PR DESCRIPTION
If the visualization frame is rendered faster than the frametime, the main application loop will sleep until the next draw frame. Unlocking the framerate during video rendering will enable faster renders.

Ideally, instead of using `MUSIALIZER_TARGET_FPS` in `plug.c` we would query target fps from Raylib, but it doesn't provide such api.
