### PR TITLE
fix: adding signal.h to pass build for macOS

### DIFF
--- a/src/ffmpeg_linux.c
+++ b/src/ffmpeg_linux.c
@@ -1,3 +1,4 @@
+#include <signal.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/src/nob_macos.c
+++ b/src/nob_macos.c
@@ -1,4 +1,3 @@
-// TODO: confirm that MacOS build works on MacOS
 #define MUSIALIZER_TARGET_NAME "macos"
 
 bool build_musializer(void)


### PR DESCRIPTION
- Tested on `Linux` and `macOS`.
- Should solve the missing `kill()` rambling from the compiler.
- Closes #110.
- Drop `TODO` about testing build on `macOS` after ensuring the build works.