### PR TITLE
raylib: cherry-pick fix for setting feature macros

### DIFF
--- a/raylib/raylib-5.0/src/rcore.c
+++ b/raylib/raylib-5.0/src/rcore.c
@@ -82,6 +82,19 @@
 *
 **********************************************************************************************/
 
+//----------------------------------------------------------------------------------
+// Feature Test Macros required for this module
+//----------------------------------------------------------------------------------
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && (_XOPEN_SOURCE < 500)
+    #undef _XOPEN_SOURCE
+    #define _XOPEN_SOURCE 500 // Required for: readlink if compiled with c99 without gnu ext.
+#endif
+
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && (_POSIX_C_SOURCE < 199309L)
+    #undef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 199309L // Required for: CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+#endif
+
 #include "raylib.h"                 // Declares module functions
 
 // Check if config flags have been externally provided on compilation line
@@ -234,11 +247,6 @@ __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigne
 #define FLAG_CLEAR(n, f) ((n) &= ~(f))
 #define FLAG_TOGGLE(n, f) ((n) ^= (f))
 #define FLAG_CHECK(n, f) ((n) & (f))
-
-#if (defined(__linux__) || defined(PLATFORM_WEB)) && (_POSIX_C_SOURCE < 199309L)
-    #undef _POSIX_C_SOURCE
-    #define _POSIX_C_SOURCE 199309L // Required for: CLOCK_MONOTONIC if compiled with c99 without gnu ext.
-#endif
 
 //----------------------------------------------------------------------------------
 // Types and Structures Definition

--- a/raylib/raylib-5.0/src/rglfw.c
+++ b/raylib/raylib-5.0/src/rglfw.c
@@ -37,6 +37,18 @@
 // _GLFW_OSMESA     to use the OSMesa API (headless and non-interactive)
 // _GLFW_MIR        experimental, not supported at this moment
 
+//----------------------------------------------------------------------------------
+// Feature Test Macros required for this module
+//----------------------------------------------------------------------------------
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && (_POSIX_C_SOURCE < 199309L)
+    #undef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 199309L // Required for: CLOCK_MONOTONIC if compiled with c99 without gnu ext.
+#endif
+#if (defined(__linux__) || defined(PLATFORM_WEB)) && !defined(_GNU_SOURCE)
+    #undef _GNU_SOURCE
+    #define _GNU_SOURCE // Required for: ppoll if compiled with c99 without gnu ext.
+#endif
+
 #if defined(_WIN32) || defined(__CYGWIN__)
     #define _GLFW_WIN32
 #endif


### PR DESCRIPTION
When trying to build musializer, I encountered the following error:

```
In file included from ./raylib/raylib-5.0/src/rglfw.c:87:
./raylib/raylib-5.0/src/external/glfw/src/posix_poll.c: In function '_glfwPollPOSIX':
./raylib/raylib-5.0/src/external/glfw/src/posix_poll.c:49:32: error: implicit declaration of function 'ppoll'; did you mean 'poll'? [-Wimplicit-function-declaration]
   49 |             const int result = ppoll(fds, count, &ts, NULL);
      |                                ^~~~~
      |                                poll
```

It turns out that raylib has a fix for this in master (https://github.com/raysan5/raylib/commit/192f7f1b291d21fbe4bdd2c373e6cf94e69272bb). Applying it fixed the issue for me.

This fixes the issue underlying #20.