### PR TITLE
Update nob.yaml

### DIFF
--- a/.github/workflows/nob.yaml
+++ b/.github/workflows/nob.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Run nob
         run: ./nob
       - name: Upload build folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos-build-folder
           path: build/
@@ -31,17 +31,16 @@ jobs:
       - name: Run nob
         run: ./nob
       - name: Upload build folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ubuntu-${{ matrix.cc }}-build-folder
           path: build/
   windows:
+    name: windows (${{ matrix.hotreload == true && 'hotreload' || '' }})
     runs-on: windows-latest
     strategy:
       matrix:
-        hotreload:
-          - "/DMUSIALIZER_HOTRELOAD"
-          - ""
+        hotreload: [true, false]
     steps:
       - name: Clone GIT repo
         uses: actions/checkout@v4
@@ -53,14 +52,14 @@ jobs:
         # https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#create-your-own-command-prompt-shortcut
         run: |
           call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
-          cl.exe ${{ matrix.hotreload }} -o nob.exe nob.c
+          cl.exe ${{ matrix.hotreload == true && '/DMUSIALIZER_HOTRELOAD' || '' }} /Fenob nob.c
       - name: Run nob
         shell: cmd
         run: |
           call "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat"
           nob.exe
       - name: Upload build folder
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: windows-build-folder
+          name: windows-${{ matrix.hotreload == true && 'hotreload' || '' }}-build-folder
           path: build/


### PR DESCRIPTION
This fixes windows build artifacts by separating hotreloaded from classic windows build.

Refactor of hotreload:
- hotreload is a true/false matrix variable;
- Substitute it with appropriate strings in places

What it does:

**Matrix: windows**
- windows ()
- windows (hotreload)

**Artifacts**
- windows--build-folder 
- windows-hotreload-build-folder 
- ...

upload-artifact action updated to v4 because of [Deprecation notice: v1, v2, and v3 of the artifact actions](https://github.com/tsoding/musializer/actions/runs/11539213295/workflow).

Changed `-o` to `/Fe` in cl.exe args to fix `cl : Command line warning D9035 : option 'o' has been deprecated and will be removed in a future release` (see it [in logs](https://github.com/tsoding/musializer/actions/runs/11539213295/job/32118624811#step:3:14)).