### PR TITLE
Add tinyfiledialogs.c to nob_macos.c

### DIFF
--- a/src_build/nob_macos.c
+++ b/src_build/nob_macos.c
@@ -20,7 +20,8 @@ bool build_musializer(void)
         nob_cmd_append(&cmd, "-o", "./build/libplug.dylib");
         nob_cmd_append(&cmd,
             "./src/plug.c",
-            "./src/ffmpeg_linux.c");
+            "./src/ffmpeg_linux.c",
+            "./src/tinyfiledialogs.c");
         nob_cmd_append(&cmd, "./build/raylib/macos/libraylib.dylib");
         nob_cmd_append(&cmd, "-lm", "-ldl", "-lpthread");
     nob_da_append(&procs, nob_cmd_run_async(cmd));
@@ -52,7 +53,8 @@ bool build_musializer(void)
         nob_cmd_append(&cmd,
             "./src/plug.c",
             "./src/ffmpeg_linux.c",
-            "./src/musializer.c");
+            "./src/musializer.c",
+            "./src/tinyfiledialogs.c");
         nob_cmd_append(&cmd, "./build/raylib/macos/libraylib.a");
 
         nob_cmd_append(&cmd, "-framework", "CoreVideo");


### PR DESCRIPTION
This PR adds tinyfiledialogs.c to nob_macos.c as mentioned here https://github.com/tsoding/musializer/issues/126#issuecomment-2796532165 by [sbela](https://github.com/sbela).
It makes the MacOS build succeed without any errors. 🎉

<img width="1392" alt="image" src="https://github.com/user-attachments/assets/768c9924-67e9-4556-93ff-69b8a3c23f52" />
