### PR TITLE
Nix Flake for dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ On Debian, Ubuntu, etc, do this:
 $ sudo apt install libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev
 ```
 
+Or using [Nix](https://nixos.org) (with [experimental
+features](https://nix.dev/manual/nix/2.30/development/experimental-features)
+`nix-command` and `flakes` enabled), navigate to the repo root and run:
+
+```console
+$ nix develop
+```
+
+This is particularly useful for building and running Musializer on
+non-[FHS](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)-compliant
+distros such as NixOS and GNU Guix System.
+
 On other distro's, use the appropriate package manager.
 
 ### Windows MSVC

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754498491,
+        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,37 @@
+{
+  description = "Flake for building and running Musializer";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        compileTimeDeps = xorgDeps;
+        runtimeDeps = xorgDeps ++ (with pkgs; [ libGL ]);
+        xorgDeps = with pkgs.xorg; [
+          libX11
+          libXcursor
+          libXrandr
+          libXinerama
+          libXi
+        ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = compileTimeDeps;
+          LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath runtimeDeps}:$LD_LIBRARY_PATH";
+          PATH = "${pkgs.lib.makeBinPath (with pkgs; [ ffmpeg ])}:$PATH";
+        };
+      }
+    );
+}


### PR DESCRIPTION
This makes building and running Musializer on NixOS and other non-FHS-compliant distros easier.