### PR TITLE
Windows: fix crash when rendering video

### DIFF
--- a/src/ffmpeg_windows.c
+++ b/src/ffmpeg_windows.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 #define WIN32_LEAN_AND_MEAN
 #define _WINUSER_


### PR DESCRIPTION
Becuase stdlib.h was not included, malloc was not declared anywhere. In C, using an undeclared function makes the compiler pretend that it's declared and has a signature of

int func();

meaning that the return value is a 32 bit int and the parameters can be whatever.

As a result of this, after the malloc call, the compiler would insert an instruction to sign extend the lower 32 bits of the RAX register into the upper 32 bits, which would of course create a pointer that is invalid in a lot of cases.

Fixes https://github.com/tsoding/musializer/issues/137 though I only found this bug report after I already wrote all this other shit